### PR TITLE
Add spec.llm.providers.type

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ spec:
       - name: gpt-3.5-turbo
       name: openai
       url: https://api.openai.com/v1
+      type: openai
     - credentialsSecretRef:
         name: bam-api-keys
       models:
       - name: ibm/granite-13b-chat-v2
       name: bam
       url: https://bam-api.res.ibm.com
+      type: bam
   ols:
     conversationCache:
       redis:


### PR DESCRIPTION
Without the type defined, the OLSConfig is invalid.

The OLSConfig "cluster" is invalid: 
* spec.llm.providers[0].type: Required value
* spec.llm.providers[1].type: Required value

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
